### PR TITLE
Update example to use GoogleMapLoader and GoogleMapElement

### DIFF
--- a/src/scripts/SimpleMap.js
+++ b/src/scripts/SimpleMap.js
@@ -1,6 +1,5 @@
 import {default as React, Component} from "react";
-
-import {GoogleMap, Marker} from "react-google-maps";
+import {GoogleMapLoader, GoogleMap, Marker} from "react-google-maps";
 
 /*
  * This is the modify version of:
@@ -11,26 +10,36 @@ import {GoogleMap, Marker} from "react-google-maps";
  * We use React 0.14 stateless function components here.
  * https://facebook.github.io/react/blog/2015/09/10/react-v0.14-rc1.html#stateless-function-components
  */
+
 export default function SimpleMap (props) {
   return (
     <section style={{height: "100%"}}>
-      <GoogleMap containerProps={{
-          style: {
-            height: "100%",
-          },
-        }}
-        defaultZoom={3}
-        defaultCenter={{lat: -25.363882, lng: 131.044922}}
-        onClick={props.onMapClick}
-      >
-        {props.markers.map((marker, index) => {
-          return (
-            <Marker
-              {...marker}
-              onRightclick={() => props.onMarkerRightclick(index)} />
-          );
-        })}
-      </GoogleMap>
+      <GoogleMapLoader
+        containerElement={
+          <div
+            {...props.containerElementProps}
+            style={{
+              height: "100%",
+            }}
+          />
+        }
+        googleMapElement={
+          <GoogleMap
+            ref={(map) => console.log(map)}
+            defaultZoom={3}
+            defaultCenter={{ lat: -25.363882, lng: 131.044922 }}
+            onClick={props.onMapClick}
+          >
+            {props.markers.map((marker, index) => {
+              return (
+                <Marker
+                  {...marker}
+                  onRightclick={() => props.onMarkerRightclick(index)} />
+              );
+            })}
+          </GoogleMap>
+        }
+      />
     </section>
   );
 }


### PR DESCRIPTION
This example throws a deprecation error when using with the latest version of react-google-maps, for using the old GoogleMap component, which has since been broken down into GoogleMapLoader and GoogleMapElement. I copied this code from the project README.